### PR TITLE
[Feat] 회원가입, 로그인 기능 추가

### DIFF
--- a/src/main/java/com/server/erentronic/common/address/Address.java
+++ b/src/main/java/com/server/erentronic/common/address/Address.java
@@ -4,11 +4,9 @@ import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString
 @Getter
 public class Address {
 

--- a/src/main/java/com/server/erentronic/common/controlleradvice/RequestBodyControllerAdvice.java
+++ b/src/main/java/com/server/erentronic/common/controlleradvice/RequestBodyControllerAdvice.java
@@ -1,0 +1,59 @@
+package com.server.erentronic.common.controlleradvice;
+
+import com.server.erentronic.common.member.dto.SignUpRequest;
+import com.server.erentronic.common.utils.Sha256;
+import java.lang.reflect.Type;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdvice;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class RequestBodyControllerAdvice implements RequestBodyAdvice {
+
+	private final Sha256 sha256;
+
+	@Override
+	public boolean supports(final MethodParameter methodParameter, final Type targetType,
+		final Class<? extends HttpMessageConverter<?>> converterType) {
+
+		return targetType.getTypeName().equals(SignUpRequest.class.getTypeName());
+	}
+
+	@Override
+	public HttpInputMessage beforeBodyRead(final HttpInputMessage inputMessage,
+		final MethodParameter parameter, final Type targetType,
+		final Class<? extends HttpMessageConverter<?>> converterType) {
+
+		return inputMessage;
+	}
+
+	@Override
+	public Object afterBodyRead(final Object body, final HttpInputMessage inputMessage,
+		final MethodParameter parameter, final Type targetType,
+		final Class<? extends HttpMessageConverter<?>> converterType) {
+
+		final SignUpRequest signUpRequest = (SignUpRequest) body;
+
+		//todo 비밀번호 정규식으로 체크!
+
+		try {
+			String encodedPassword = sha256.encrypt(signUpRequest.getPassword());
+			signUpRequest.setPassword(encodedPassword);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		return signUpRequest;
+	}
+
+	@Override
+	public Object handleEmptyBody(final Object body, final HttpInputMessage inputMessage,
+		final MethodParameter parameter, final Type targetType,
+		final Class<? extends HttpMessageConverter<?>> converterType) {
+		return body;
+	}
+}

--- a/src/main/java/com/server/erentronic/common/member/Member.java
+++ b/src/main/java/com/server/erentronic/common/member/Member.java
@@ -8,6 +8,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.Email;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,8 +16,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Member {
-
-	//todo 로그인id, 로그인 패스워드에 대한 필드 추가해야 함
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,6 +26,17 @@ public class Member {
 	@Email
 	private String email;
 
+	private String password;
+
 	@Embedded
 	private Address address;
+
+	@Builder
+	private Member(Long id, String name, String email, String password, Address address) {
+		this.id = id;
+		this.name = name;
+		this.email = email;
+		this.password = password;
+		this.address = address;
+	}
 }

--- a/src/main/java/com/server/erentronic/common/member/controller/MemberController.java
+++ b/src/main/java/com/server/erentronic/common/member/controller/MemberController.java
@@ -1,0 +1,24 @@
+package com.server.erentronic.common.member.controller;
+
+import com.server.erentronic.common.dto.CUDResponse;
+import com.server.erentronic.common.member.dto.SignUpRequest;
+import com.server.erentronic.common.member.service.MemberService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+	private final MemberService memberService;
+
+	@PostMapping
+	public CUDResponse signUp(@RequestBody @Valid SignUpRequest signUpRequest){
+		return memberService.singUp(signUpRequest);
+	}
+}

--- a/src/main/java/com/server/erentronic/common/member/dto/SignUpRequest.java
+++ b/src/main/java/com/server/erentronic/common/member/dto/SignUpRequest.java
@@ -1,0 +1,39 @@
+package com.server.erentronic.common.member.dto;
+
+import com.server.erentronic.common.address.Address;
+import com.server.erentronic.common.member.Member;
+import javax.validation.Valid;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Setter
+public class SignUpRequest {
+
+	@NotEmpty
+	private String name;
+
+	@Email
+	private String email;
+
+	@NotEmpty
+	private String password;
+
+	@Valid
+	private Address address;
+
+	public Member toEntity() {
+
+		return Member.builder()
+			.name(name)
+			.email(email)
+			.password(password)
+			.address(address)
+			.build();
+	}
+}

--- a/src/main/java/com/server/erentronic/common/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/erentronic/common/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
-package com.server.erentronic.common.member;
+package com.server.erentronic.common.member.repository;
 
+import com.server.erentronic.common.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {

--- a/src/main/java/com/server/erentronic/common/member/service/MemberService.java
+++ b/src/main/java/com/server/erentronic/common/member/service/MemberService.java
@@ -1,0 +1,30 @@
+package com.server.erentronic.common.member.service;
+
+import com.server.erentronic.common.dto.CUDResponse;
+import com.server.erentronic.common.member.Member;
+import com.server.erentronic.common.member.dto.SignUpRequest;
+import com.server.erentronic.common.member.repository.MemberRepository;
+import com.server.erentronic.common.message.Message;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public CUDResponse singUp(SignUpRequest signUpRequest) {
+		//todo email 중복 체크
+
+		log.info("password: {}", signUpRequest.getPassword());
+
+		Member member = signUpRequest.toEntity();
+		memberRepository.save(member);
+		return CUDResponse.of(member.getId(), Message.MEMBER_SIGN_UP_MESSAGE);
+	}
+}

--- a/src/main/java/com/server/erentronic/common/message/Message.java
+++ b/src/main/java/com/server/erentronic/common/message/Message.java
@@ -13,7 +13,9 @@ public enum Message {
 
 	PRODUCT_CREATED_MESSAGE("상품이 등록되었습니다."),
 	PRODUCT_DELETED_MESSAGE("상품이 삭제되었습니다."),
-	PRODUCT_PATCHED_MESSAGE("상품이 수정되었습니다.");
+	PRODUCT_PATCHED_MESSAGE("상품이 수정되었습니다."),
+
+	MEMBER_SIGN_UP_MESSAGE("회원가입이 완료되었습니다.");
 
 	final String message;
 }

--- a/src/main/java/com/server/erentronic/common/order/service/OrderService.java
+++ b/src/main/java/com/server/erentronic/common/order/service/OrderService.java
@@ -6,7 +6,7 @@ import com.server.erentronic.common.exception.NoStockException;
 import com.server.erentronic.common.exception.NoSuchItemException;
 import com.server.erentronic.common.exception.NotMatchException;
 import com.server.erentronic.common.member.Member;
-import com.server.erentronic.common.member.MemberRepository;
+import com.server.erentronic.common.member.repository.MemberRepository;
 import com.server.erentronic.common.message.ErrorDetail;
 import com.server.erentronic.common.message.Message;
 import com.server.erentronic.common.order.Order;

--- a/src/main/java/com/server/erentronic/common/utils/Sha256.java
+++ b/src/main/java/com/server/erentronic/common/utils/Sha256.java
@@ -1,0 +1,29 @@
+package com.server.erentronic.common.utils;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Sha256 {
+
+	public String encrypt(String value) {
+		StringBuilder sb = new StringBuilder();
+
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-256");
+			md.update(value.getBytes());
+			byte byteData[] = md.digest();
+
+			for (byte tmpStrByte : byteData) {
+				String tmpEncTxt = Integer.toString((tmpStrByte & 0xff) + 0x100, 16).substring(1);
+
+				sb.append(tmpEncTxt);
+			}
+		} catch (NoSuchAlgorithmException e) {
+			e.printStackTrace();
+		}
+
+		return sb.toString();
+	}
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -26,9 +26,9 @@ VALUES ('BLUE'),
        ('BLACK'),
        ('SILENCE_RED');
 
-INSERT INTO member(name, email, full_address, address1, address2, zip_code)
+INSERT INTO member(name, email, full_address, address1, address2, zip_code, password)
 VALUES ('name', 'mock@mock.com', '서울 송파구 송파대로 567 101동 101호', '서울 송파구 송파대로 567', '101동 101호',
-        '05503');
+        '05503', 'password1234');
 
 INSERT INTO discount_policy(title, rate)
 VALUES ('이벤트 할인', 0.0225),


### PR DESCRIPTION
### 구현 사항

- 회원가입, 로그인 시 패스워드를 단방향 해시 알고리즘 (SHA256) 을 활용하여 암호화하는 기능 추가
- `RequestBodyAdvice` 을 활용한 RequestBody 조작
- Member 엔티티에 누락된 패스워드 필드 추가
- 회원가입 요청 SignUpRequest, 로그인 요청 LoginRequest Dto 클래스 추가