### PR TITLE
[Feat] 주문 내역 조회 기능 구현

### DIFF
--- a/src/main/java/com/server/erentronic/common/message/ErrorDetail.java
+++ b/src/main/java/com/server/erentronic/common/message/ErrorDetail.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorDetail {
 
 	INVALID_INPUT_VALUE("입력 값이 올바르지 않습니다.", 400),
-	INVALID_RENTAL_PERIOD("대여 시작일이 대여 종료일 이전이어야합니다.", 400),
+	INVALID_PERIOD("시작일이 종료일 이전이어야합니다.", 400),
 
 	NOT_EQUALS_REAL_PRICE("주문한 해당 상품에 대한 총 가격이 일치하지 않습니다.", 400),
 	NOT_EQUALS_REAL_TOTAL_PRICE("주문한 모든 상품에 대한 총 가격이 일치하지 않습니다.", 400),

--- a/src/main/java/com/server/erentronic/common/order/Order.java
+++ b/src/main/java/com/server/erentronic/common/order/Order.java
@@ -1,6 +1,7 @@
 package com.server.erentronic.common.order;
 
 import com.server.erentronic.item.product.Product;
+import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Inheritance(strategy = InheritanceType.JOINED)
-@DiscriminatorColumn
+@DiscriminatorColumn(name = "dtype")
 @Table(name = "orders")
 @Getter
 public abstract class Order {
@@ -27,6 +28,9 @@ public abstract class Order {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	protected Long id;
+
+	@Column(insertable = false, updatable = false)
+	protected String dtype;
 
 	@JoinColumn
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/server/erentronic/common/order/Order.java
+++ b/src/main/java/com/server/erentronic/common/order/Order.java
@@ -53,4 +53,8 @@ public abstract class Order {
 	public void assignOrderSheet(OrderSheet orderSheet) {
 		this.orderSheet = orderSheet;
 	}
+
+	public boolean isOrderType(String dtype) {
+		return dtype == null || this.dtype.equals(dtype);
+	}
 }

--- a/src/main/java/com/server/erentronic/common/order/controller/OrderController.java
+++ b/src/main/java/com/server/erentronic/common/order/controller/OrderController.java
@@ -2,11 +2,15 @@ package com.server.erentronic.common.order.controller;
 
 import com.server.erentronic.auth.annotation.LoginId;
 import com.server.erentronic.common.dto.CUDResponse;
-import com.server.erentronic.common.member.Member;
+import com.server.erentronic.common.order.dto.OrderHistoryResponses;
+import com.server.erentronic.common.order.dto.OrderSearchRequest;
 import com.server.erentronic.common.order.dto.OrderSheetRequest;
 import com.server.erentronic.common.order.service.OrderService;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,6 +24,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
 	private final OrderService orderService;
+
+	@GetMapping
+	public List<OrderHistoryResponses> getOrderHistory(@LoginId Long memberId, @ModelAttribute OrderSearchRequest orderSearchRequest) {
+		return orderService.getOrderHistory(memberId, orderSearchRequest);
+	}
 
 	@PostMapping
 	public CUDResponse order(@LoginId Long memberId, @RequestBody @Valid OrderSheetRequest orderSheetRequest) {

--- a/src/main/java/com/server/erentronic/common/order/dto/OrderHistoryResponse.java
+++ b/src/main/java/com/server/erentronic/common/order/dto/OrderHistoryResponse.java
@@ -1,0 +1,34 @@
+package com.server.erentronic.common.order.dto;
+
+import com.server.erentronic.common.order.Order;
+import com.server.erentronic.item.product.dto.ProductResponse;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class OrderHistoryResponse {
+
+	private final Long orderId;
+
+	private final String dtype;
+
+	private final ProductResponse product;
+
+	private final Double totalDiscountRate;
+
+	private final String discountDetail;
+
+	private final Integer quantity;
+
+	private final Integer price;
+
+	private final Integer salePrice;
+
+	public static OrderHistoryResponse from(Order order) {
+		return new OrderHistoryResponse(order.getId(), order.getDtype(),
+			ProductResponse.from(order.getProduct()), order.getTotalDiscountRate(),
+			order.getDiscountDetail(), order.getQuantity(), order.getPrice(), order.getSalePrice());
+	}
+}

--- a/src/main/java/com/server/erentronic/common/order/dto/OrderHistoryResponses.java
+++ b/src/main/java/com/server/erentronic/common/order/dto/OrderHistoryResponses.java
@@ -1,0 +1,45 @@
+package com.server.erentronic.common.order.dto;
+
+import com.server.erentronic.common.address.Address;
+import com.server.erentronic.common.order.Order;
+import com.server.erentronic.common.order.OrderSheet;
+import com.server.erentronic.common.order.OrderState;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class OrderHistoryResponses {
+
+	private final Long orderSheetId;
+
+	private final LocalDateTime createAt;
+
+	private final Address address;
+
+	private final Integer totalPrice;
+
+	private final OrderState state;
+
+	private final List<OrderHistoryResponse> orderHistoryResponses;
+
+	public static OrderHistoryResponses from(OrderSheet orderSheets, String dtype) {
+		List<Order> orders = orderSheets.getOrders();
+		List<OrderHistoryResponse> orderHistoryResponses = orders.stream()
+			.filter(order -> order.isOrderType(dtype))
+			.map(OrderHistoryResponse::from)
+			.collect(Collectors.toList());
+
+		return new OrderHistoryResponses(
+			orderSheets.getId(),
+			orderSheets.getCreatedAt(),
+			orderSheets.getAddress(),
+			orderSheets.getTotalPrice(),
+			orderSheets.getState(),
+			orderHistoryResponses);
+	}
+}

--- a/src/main/java/com/server/erentronic/common/order/dto/OrderSearchRequest.java
+++ b/src/main/java/com/server/erentronic/common/order/dto/OrderSearchRequest.java
@@ -1,0 +1,24 @@
+package com.server.erentronic.common.order.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+
+@Getter
+public class OrderSearchRequest {
+
+	private String dtype;
+
+	@DateTimeFormat(iso = ISO.DATE)
+	private LocalDate startDate;
+
+	@DateTimeFormat(iso = ISO.DATE)
+	private LocalDate endDate;
+
+	private OrderSearchRequest(String dtype, LocalDate startDate, LocalDate endDate) {
+		this.dtype = dtype;
+		this.startDate = startDate == null ? LocalDate.now() : startDate;
+		this.endDate = endDate == null ? LocalDate.now().minusMonths(3L) : endDate;
+	}
+}

--- a/src/main/java/com/server/erentronic/common/order/repository/OrderSheetRepository.java
+++ b/src/main/java/com/server/erentronic/common/order/repository/OrderSheetRepository.java
@@ -1,8 +1,19 @@
 package com.server.erentronic.common.order.repository;
 
+import com.server.erentronic.common.member.Member;
 import com.server.erentronic.common.order.OrderSheet;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderSheetRepository extends JpaRepository<OrderSheet, Long> {
 
+	@Query("select o from OrderSheet o "
+		+ "join fetch o.orders "
+		+ "where (o.createdAt between :start and :end) "
+		+ "and (o.member = :member)")
+	List<OrderSheet> findWithinSpecificPeriod(@Param("member") Member member,
+		@Param("start") LocalDateTime startDateTime, @Param("end") LocalDateTime endDateTime);
 }

--- a/src/main/java/com/server/erentronic/common/order/service/OrderService.java
+++ b/src/main/java/com/server/erentronic/common/order/service/OrderService.java
@@ -132,7 +132,7 @@ public class OrderService {
 
 		LocalDateTime startDateTime = rentalRequest.getStartDateTime();
 		LocalDateTime endDateTime = rentalRequest.getEndDateTime();
-		validateRentalPeriod(startDateTime, endDateTime);
+		DateUtil.validatePeriod(startDateTime, endDateTime);
 
 		Rental rental = Rental.makeRental(product, rentalRequest.getQuantity(),
 			startDateTime, endDateTime, rentalRequest.getProductTotalPrice());
@@ -181,13 +181,6 @@ public class OrderService {
 		prevOrderSheet.changeState(OrderState.CANCELED);
 
 		return CUDResponse.of(orderSheetId, Message.ORDER_CANCEL_MESSAGE);
-	}
-  
-  private void validateRentalPeriod(LocalDateTime startDateTime, LocalDateTime endDateTime) {
-		if (startDateTime.toLocalDate().isEqual(endDateTime.toLocalDate())
-			|| startDateTime.toLocalDate().isAfter(endDateTime.toLocalDate())) {
-			throw new InvalidInputException(ErrorDetail.INVALID_RENTAL_PERIOD);
-		}
 	}
 
 	private void validateTotalPrice(Integer orderTotalPrice, Integer calculatedTotalPrice) {

--- a/src/main/java/com/server/erentronic/common/utils/DateUtil.java
+++ b/src/main/java/com/server/erentronic/common/utils/DateUtil.java
@@ -1,0 +1,19 @@
+package com.server.erentronic.common.utils;
+
+import com.server.erentronic.common.exception.InvalidInputException;
+import com.server.erentronic.common.message.ErrorDetail;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DateUtil {
+
+	public static void validatePeriod(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+		if (startDateTime.toLocalDate().isEqual(endDateTime.toLocalDate())
+			|| startDateTime.toLocalDate().isAfter(endDateTime.toLocalDate())) {
+			throw new InvalidInputException(ErrorDetail.INVALID_PERIOD);
+		}
+	}
+}


### PR DESCRIPTION
### 구현 사항

- 주문 내역 조회 기능 구현
- 주문한 회원이 로그인 했을 시에만 조회할 수 있도록 함
- 동일한 회원의 주문 내역만 보여줌
- 조회 시 dtype, startDate, endDate가 없이 조회하면 default로 구매와 대여에 관한 최근 3개월간의 데이터를 보여줌
